### PR TITLE
Fix transactional PNG conversion

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ const packageJson = JSON.parse(fs.readFileSync(findPackageJson(), "utf8"));
  */
 async function parseArguments(): Promise<Args> {
   const parsed = await yargs(hideBin(process.argv))
-    .usage(`${packageJson.description}\n\nUsage: pnpm build [options]`)
+    .usage(`${packageJson.description}\n\nUsage: epub-optimizer [options]`)
     .option("input", {
       alias: "i",
       describe: "Input EPUB file path",
@@ -65,12 +65,12 @@ async function parseArguments(): Promise<Args> {
       type: "boolean",
       default: false,
     })
-    .example("pnpm build -i book.epub -o book-optimized.epub", "Basic optimization")
-    .example("pnpm build:clean -i book.epub -o book-opt.epub", "Optimize and clean temp files")
-    .example("pnpm build -i book.epub -o book-opt.epub --jpg-quality 85", "Higher JPEG quality")
-    .example("pnpm build -i book.epub -o book-opt.epub --png-quality 0.9", "Higher PNG quality")
+    .example("pnpm optimize -i book.epub -o book-optimized.epub", "Basic optimization")
+    .example("pnpm optimize -i book.epub -o book-opt.epub --clean", "Optimize and clean temp files")
+    .example("pnpm optimize -i book.epub -o book-opt.epub --jpg-quality 85", "Higher JPEG quality")
+    .example("pnpm optimize -i book.epub -o book-opt.epub --png-quality 0.9", "Higher PNG quality")
     .example(
-      "pnpm build -i input.epub -o output.epub --jpg-quality 85 --png-quality 0.8",
+      "epub-optimizer -i input.epub -o output.epub --jpg-quality 85 --png-quality 0.8",
       "Custom image settings"
     )
     .help()

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -45,6 +45,10 @@ vi.mock("./processors/image-processor.js", () => ({
   optimizeImages: vi.fn().mockResolvedValue(10),
 }));
 
+vi.mock("./processors/image-converter.js", () => ({
+  convertPngToJpeg: vi.fn().mockResolvedValue(new Set()),
+}));
+
 // Import after mocking
 beforeEach(async () => {
   // Import the module dynamically to get the mocked version

--- a/src/processors/image-converter.test.ts
+++ b/src/processors/image-converter.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs-extra";
+import path from "node:path";
+import os from "node:os";
+import sharp from "sharp";
+import { convertPngToJpeg } from "./image-converter.js";
+
+const tempDir = path.join(os.tmpdir(), "epub-optimizer-image-converter-test");
+
+async function createLargeOpaquePng(filePath: string): Promise<void> {
+  const width = 500;
+  const height = 500;
+  const raw = Buffer.alloc(width * height * 3);
+  let seed = 123456789;
+
+  for (let index = 0; index < raw.length; index++) {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    raw[index] = (seed >>> 24) & 0xff;
+  }
+
+  await sharp(raw, { raw: { width, height, channels: 3 } })
+    .png()
+    .toFile(filePath);
+}
+
+async function createSmallOpaquePng(filePath: string): Promise<void> {
+  await sharp({
+    create: {
+      width: 20,
+      height: 20,
+      channels: 3,
+      background: { r: 20, g: 120, b: 220 },
+    },
+  })
+    .png()
+    .toFile(filePath);
+}
+
+async function createEpubTree(
+  epubDir: string,
+  opts: { includeCatManifest?: boolean; includeCatReferences?: boolean } = {}
+): Promise<void> {
+  const includeCatManifest = opts.includeCatManifest ?? true;
+  const includeCatReferences = opts.includeCatReferences ?? true;
+  const contentDir = path.join(epubDir, "OPS");
+
+  await fs.ensureDir(path.join(epubDir, "META-INF"));
+  await fs.ensureDir(path.join(contentDir, "chapters"));
+  await fs.ensureDir(path.join(contentDir, "images"));
+  await fs.ensureDir(path.join(contentDir, "styles"));
+  await fs.ensureDir(path.join(contentDir, "vector"));
+
+  await fs.writeFile(path.join(epubDir, "mimetype"), "application/epub+zip");
+  await fs.writeFile(
+    path.join(epubDir, "META-INF", "container.xml"),
+    `<?xml version="1.0"?>
+    <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+      <rootfiles>
+        <rootfile full-path="OPS/content.opf" media-type="application/oebps-package+xml"/>
+      </rootfiles>
+    </container>`
+  );
+
+  await fs.writeFile(
+    path.join(contentDir, "content.opf"),
+    `<?xml version="1.0"?>
+    <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+      <metadata>
+        <dc:title>Image Converter Test</dc:title>
+        <dc:language>en</dc:language>
+        <dc:identifier>test-id</dc:identifier>
+      </metadata>
+      <manifest>
+        <item id="chapter" href="chapters/chapter-1.xhtml" media-type="application/xhtml+xml"/>
+        <item id="style" href="styles/book.css" media-type="text/css"/>
+        <item id="graphic" href="vector/graphic.svg" media-type="image/svg+xml"/>
+        ${includeCatManifest ? '<item id="cat" href="images/cat.png" media-type="image/png"/>' : ""}
+        <item id="scat" href="images/scat.png" media-type="image/png"/>
+      </manifest>
+      <spine>
+        <itemref idref="chapter"/>
+      </spine>
+    </package>`
+  );
+
+  await createLargeOpaquePng(path.join(contentDir, "images", "cat.png"));
+  await createSmallOpaquePng(path.join(contentDir, "images", "scat.png"));
+
+  await fs.writeFile(
+    path.join(contentDir, "chapters", "chapter-1.xhtml"),
+    includeCatReferences
+      ? `<?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml">
+          <head>
+            <link rel="stylesheet" href="../styles/book.css" />
+          </head>
+          <body>
+            <img src="../images/cat.png" alt="cat" />
+            <img src="../images/scat.png" alt="scat" />
+            <img srcset="../images/cat.png 1x, ../images/cat.png?density=2 2x" alt="cat set" />
+            <picture><source srcset="../images/cat.png 640w" /></picture>
+            <div style="background-image:url(&apos;../images/cat.png#inline&apos;)"></div>
+          </body>
+        </html>`
+      : `<?xml version="1.0" encoding="UTF-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml">
+          <body><img src="../images/scat.png" alt="scat" /></body>
+        </html>`
+  );
+
+  await fs.writeFile(
+    path.join(contentDir, "styles", "book.css"),
+    includeCatReferences
+      ? `.hero { background-image: url("../images/cat.png#css"); }
+        .retina { background-image: image-set(url("../images/cat.png") 1x, "../images/cat.png?css=2" 2x); }
+        .scat { background-image: url("../images/scat.png"); }`
+      : `.scat { background-image: url("../images/scat.png"); }`
+  );
+
+  await fs.writeFile(
+    path.join(contentDir, "vector", "graphic.svg"),
+    includeCatReferences
+      ? `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <image href="../images/cat.png" />
+          <image xlink:href="../images/cat.png?svg=1" />
+        </svg>`
+      : `<svg xmlns="http://www.w3.org/2000/svg"></svg>`
+  );
+}
+
+describe("PNG to JPEG converter", () => {
+  beforeEach(async () => {
+    await fs.ensureDir(tempDir);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+    vi.restoreAllMocks();
+  });
+
+  it("commits only exact resolved PNG references across nested XHTML, CSS, srcset, and SVG", async () => {
+    const epubDir = path.join(tempDir, "commit");
+    const contentDir = path.join(epubDir, "OPS");
+    const catPng = path.join(contentDir, "images", "cat.png");
+    const catJpg = path.join(contentDir, "images", "cat.jpg");
+    const scatPng = path.join(contentDir, "images", "scat.png");
+    const scatJpg = path.join(contentDir, "images", "scat.jpg");
+
+    await createEpubTree(epubDir);
+
+    const converted = await convertPngToJpeg(epubDir, 70, 1);
+
+    expect(Array.from(converted)).toEqual([catJpg]);
+    expect(await fs.pathExists(catPng)).toBe(false);
+    expect(await fs.pathExists(catJpg)).toBe(true);
+    expect(await fs.pathExists(scatPng)).toBe(true);
+    expect(await fs.pathExists(scatJpg)).toBe(false);
+
+    const chapter = await fs.readFile(path.join(contentDir, "chapters", "chapter-1.xhtml"), "utf8");
+    expect(chapter).toContain('src="../images/cat.jpg"');
+    expect(chapter).toContain("../images/cat.jpg?density=2 2x");
+    expect(chapter).toContain("../images/cat.jpg 640w");
+    expect(chapter).toContain("url(&apos;../images/cat.jpg#inline&apos;)");
+    expect(chapter).toContain('src="../images/scat.png"');
+    expect(chapter).not.toContain("scat.jpg");
+
+    const css = await fs.readFile(path.join(contentDir, "styles", "book.css"), "utf8");
+    expect(css).toContain('url("../images/cat.jpg#css")');
+    expect(css).toContain('url("../images/cat.jpg") 1x');
+    expect(css).toContain('"../images/cat.jpg?css=2" 2x');
+    expect(css).toContain('url("../images/scat.png")');
+    expect(css).not.toContain("scat.jpg");
+
+    const svg = await fs.readFile(path.join(contentDir, "vector", "graphic.svg"), "utf8");
+    expect(svg).toContain('href="../images/cat.jpg"');
+    expect(svg).toContain('xlink:href="../images/cat.jpg?svg=1"');
+
+    const opf = await fs.readFile(path.join(contentDir, "content.opf"), "utf8");
+    expect(opf).toContain('href="images/cat.jpg"');
+    expect(opf).toContain('media-type="image/jpeg"');
+    expect(opf).toContain('href="images/scat.png"');
+  });
+
+  it("rolls back a JPEG candidate when no supported content reference is found", async () => {
+    const epubDir = path.join(tempDir, "unreferenced");
+    const contentDir = path.join(epubDir, "OPS");
+    const catPng = path.join(contentDir, "images", "cat.png");
+    const catJpg = path.join(contentDir, "images", "cat.jpg");
+
+    await createEpubTree(epubDir, { includeCatReferences: false });
+
+    const converted = await convertPngToJpeg(epubDir, 70, 1);
+
+    expect(converted.size).toBe(0);
+    expect(await fs.pathExists(catPng)).toBe(true);
+    expect(await fs.pathExists(catJpg)).toBe(false);
+
+    const opf = await fs.readFile(path.join(contentDir, "content.opf"), "utf8");
+    expect(opf).toContain('href="images/cat.png"');
+    expect(opf).not.toContain('href="images/cat.jpg"');
+  });
+
+  it("rolls back a JPEG candidate when the PNG has no OPF manifest item", async () => {
+    const epubDir = path.join(tempDir, "missing-opf-item");
+    const contentDir = path.join(epubDir, "OPS");
+    const catPng = path.join(contentDir, "images", "cat.png");
+    const catJpg = path.join(contentDir, "images", "cat.jpg");
+
+    await createEpubTree(epubDir, { includeCatManifest: false });
+
+    const converted = await convertPngToJpeg(epubDir, 70, 1);
+
+    expect(converted.size).toBe(0);
+    expect(await fs.pathExists(catPng)).toBe(true);
+    expect(await fs.pathExists(catJpg)).toBe(false);
+
+    const chapter = await fs.readFile(path.join(contentDir, "chapters", "chapter-1.xhtml"), "utf8");
+    expect(chapter).toContain('src="../images/cat.png"');
+    expect(chapter).not.toContain('src="../images/cat.jpg"');
+  });
+});

--- a/src/processors/image-converter.ts
+++ b/src/processors/image-converter.ts
@@ -1,7 +1,6 @@
 import fs from "fs-extra";
 import path from "node:path";
 import sharp from "sharp";
-import * as glob from "glob";
 import * as cheerio from "cheerio";
 import pLimit from "p-limit";
 import { getOPFPath, getContentPath } from "../utils/epub-utils.js";
@@ -9,14 +8,36 @@ import { getOPFPath, getContentPath } from "../utils/epub-utils.js";
 interface Conversion {
   pngFile: string;
   jpegFile: string;
-  pngBasename: string;
-  jpegBasename: string;
+  pngRel: string;
+  jpegRel: string;
   originalSize: number;
   newSize: number;
 }
 
+interface RewriteEdit {
+  pngRel: string;
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+interface RewriteStats {
+  found: number;
+  planned: number;
+}
+
+interface OpfUpdatePlan {
+  opfFile: string;
+  contentDir: string;
+  updates: Map<string, string>;
+}
+
+const CONTENT_FILE_EXTENSIONS = new Set([".xhtml", ".html", ".css", ".svg"]);
+const PNG_EXT_RE = /\.png$/i;
+
 async function maybeConvertOne(
   pngFile: string,
+  contentDir: string,
   quality: number,
   maxDim?: number
 ): Promise<Conversion | null> {
@@ -34,6 +55,11 @@ async function maybeConvertOne(
     }
 
     const jpegFile = pngFile.replace(/\.png$/i, ".jpg");
+    if (await fs.pathExists(jpegFile)) {
+      console.warn(`Skipping ${path.basename(pngFile)}: target JPEG already exists`);
+      return null;
+    }
+
     // Chain resize + encode into the single sharp pass — avoids a follow-up
     // downscale step on the freshly-written JPEG (which would otherwise be
     // skipped by optimizeImages and stay at its original dimensions).
@@ -63,8 +89,8 @@ async function maybeConvertOne(
     return {
       pngFile,
       jpegFile,
-      pngBasename: path.basename(pngFile),
-      jpegBasename: path.basename(jpegFile),
+      pngRel: toContentRel(contentDir, pngFile),
+      jpegRel: toContentRel(contentDir, jpegFile),
       originalSize,
       newSize,
     };
@@ -78,61 +104,529 @@ async function maybeConvertOne(
   }
 }
 
-async function rewriteXhtmlReferences(
-  contentDir: string,
-  conversions: Conversion[]
-): Promise<void> {
-  const xhtmlFiles = glob.sync(path.join(contentDir, "*.xhtml"));
-  const byPng = new Map(conversions.map((c) => [c.pngBasename, c.jpegBasename]));
+async function collectFiles(
+  dir: string,
+  shouldInclude: (filePath: string) => boolean
+): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
 
   await Promise.all(
-    xhtmlFiles.map(async (xhtmlFile) => {
-      const content = await fs.readFile(xhtmlFile, "utf8");
-      if (!conversions.some((c) => content.includes(c.pngBasename))) return;
-
-      const $ = cheerio.load(content, { xmlMode: true });
-      let changed = false;
-      $("img[src]").each((_, elem) => {
-        const src = $(elem).attr("src");
-        if (!src) return;
-        for (const [pngBasename, jpegBasename] of byPng) {
-          if (src.includes(pngBasename)) {
-            $(elem).attr("src", src.replace(pngBasename, jpegBasename));
-            changed = true;
-            break;
-          }
-        }
-      });
-      if (changed) {
-        await fs.writeFile(xhtmlFile, $.xml());
-        console.log(`Updated references in ${path.basename(xhtmlFile)}`);
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        out.push(...(await collectFiles(fullPath, shouldInclude)));
+      } else if (shouldInclude(fullPath)) {
+        out.push(fullPath);
       }
     })
   );
+
+  return out;
 }
 
-async function rewriteOpfManifest(epubDir: string, conversions: Conversion[]): Promise<void> {
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+function toContentRel(contentDir: string, filePath: string): string {
+  return toPosixPath(path.relative(contentDir, filePath));
+}
+
+function safeDecodeUri(value: string): string {
+  try {
+    return decodeURI(value);
+  } catch {
+    return value;
+  }
+}
+
+function splitReference(rawReference: string): { pathPart: string; suffix: string } {
+  const hashIndex = rawReference.indexOf("#");
+  const queryIndex = rawReference.indexOf("?");
+  const suffixIndex = [hashIndex, queryIndex]
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)[0];
+
+  if (suffixIndex === undefined) {
+    return { pathPart: rawReference, suffix: "" };
+  }
+
+  return {
+    pathPart: rawReference.slice(0, suffixIndex),
+    suffix: rawReference.slice(suffixIndex),
+  };
+}
+
+function isExternalReference(pathPart: string): boolean {
+  return (
+    pathPart === "" ||
+    pathPart.startsWith("#") ||
+    pathPart.startsWith("//") ||
+    /^[a-z][a-z0-9+.-]*:/i.test(pathPart)
+  );
+}
+
+function resolveReference(
+  ownerFile: string,
+  contentDir: string,
+  rawReference: string
+): { relPath: string; suffix: string } | null {
+  const trimmedReference = rawReference.trim();
+  const { pathPart, suffix } = splitReference(trimmedReference);
+  if (isExternalReference(pathPart)) return null;
+
+  const decodedPath = safeDecodeUri(pathPart).replace(/\\/g, "/");
+  const targetPath = decodedPath.startsWith("/")
+    ? path.resolve(contentDir, decodedPath.slice(1))
+    : path.resolve(path.dirname(ownerFile), decodedPath);
+  const relPath = path.relative(contentDir, targetPath);
+
+  if (relPath === "" || relPath.startsWith("..") || path.isAbsolute(relPath)) {
+    return null;
+  }
+
+  const posixRelPath = toPosixPath(relPath);
+  if (!PNG_EXT_RE.test(posixRelPath)) return null;
+
+  return { relPath: posixRelPath, suffix };
+}
+
+function replacementReference(
+  ownerFile: string,
+  contentDir: string,
+  jpegRel: string,
+  suffix: string
+): string {
+  const ownerRel = toContentRel(contentDir, ownerFile);
+  const ownerDir = path.posix.dirname(ownerRel);
+  const relativeReference = path.posix.relative(ownerDir === "." ? "" : ownerDir, jpegRel);
+  return encodeURI(relativeReference) + suffix;
+}
+
+function getStats(statsByPng: Map<string, RewriteStats>, pngRel: string): RewriteStats {
+  let stats = statsByPng.get(pngRel);
+  if (!stats) {
+    stats = { found: 0, planned: 0 };
+    statsByPng.set(pngRel, stats);
+  }
+  return stats;
+}
+
+function getReferenceToken(captured: string): { rawReference: string; startOffset: number } | null {
+  const leadingWhitespace = captured.match(/^\s*/)?.[0].length ?? 0;
+  const trailingWhitespace = captured.match(/\s*$/)?.[0].length ?? 0;
+  let startOffset = leadingWhitespace;
+  let endOffset = captured.length - trailingWhitespace;
+
+  const token = captured.slice(startOffset, endOffset);
+  const quotePairs = [
+    ["'", "'"],
+    ['"', '"'],
+    ["&apos;", "&apos;"],
+    ["&#39;", "&#39;"],
+    ["&#x27;", "&#x27;"],
+    ["&quot;", "&quot;"],
+    ["&#34;", "&#34;"],
+    ["&#x22;", "&#x22;"],
+  ] as const;
+
+  for (const [open, close] of quotePairs) {
+    if (
+      token.length >= open.length + close.length &&
+      token.slice(0, open.length).toLowerCase() === open.toLowerCase() &&
+      token.slice(-close.length).toLowerCase() === close.toLowerCase()
+    ) {
+      startOffset += open.length;
+      endOffset -= close.length;
+      break;
+    }
+  }
+
+  const rawReference = captured.slice(startOffset, endOffset);
+  if (!rawReference) return null;
+  return { rawReference, startOffset };
+}
+
+function addReferenceEdit(
+  filePath: string,
+  contentDir: string,
+  rawReference: string,
+  start: number,
+  end: number,
+  conversionsByPngRel: Map<string, Conversion>,
+  editsByFile: Map<string, RewriteEdit[]>,
+  statsByPng: Map<string, RewriteStats>
+): void {
+  const resolved = resolveReference(filePath, contentDir, rawReference);
+  if (!resolved) return;
+
+  const conversion = conversionsByPngRel.get(resolved.relPath);
+  if (!conversion) return;
+
+  const stats = getStats(statsByPng, conversion.pngRel);
+  stats.found++;
+
+  const replacement = replacementReference(
+    filePath,
+    contentDir,
+    conversion.jpegRel,
+    resolved.suffix
+  );
+  const edits = editsByFile.get(filePath) ?? [];
+  edits.push({
+    pngRel: conversion.pngRel,
+    start,
+    end,
+    replacement,
+  });
+  editsByFile.set(filePath, edits);
+  stats.planned++;
+}
+
+function scanSrcsetReferences(
+  value: string,
+  filePath: string,
+  contentDir: string,
+  valueOffset: number,
+  conversionsByPngRel: Map<string, Conversion>,
+  editsByFile: Map<string, RewriteEdit[]>,
+  statsByPng: Map<string, RewriteStats>
+): void {
+  let cursor = 0;
+
+  while (cursor <= value.length) {
+    const commaIndex = value.indexOf(",", cursor);
+    const segmentEnd = commaIndex === -1 ? value.length : commaIndex;
+    const segment = value.slice(cursor, segmentEnd);
+    const leadingWhitespace = segment.match(/^\s*/)?.[0].length ?? 0;
+    const rest = segment.slice(leadingWhitespace);
+    const urlLength = rest.search(/\s/);
+    const rawReference = rest.slice(0, urlLength === -1 ? rest.length : urlLength);
+
+    if (rawReference) {
+      const start = valueOffset + cursor + leadingWhitespace;
+      addReferenceEdit(
+        filePath,
+        contentDir,
+        rawReference,
+        start,
+        start + rawReference.length,
+        conversionsByPngRel,
+        editsByFile,
+        statsByPng
+      );
+    }
+
+    if (commaIndex === -1) break;
+    cursor = commaIndex + 1;
+  }
+}
+
+function scanCssReferences(
+  value: string,
+  filePath: string,
+  contentDir: string,
+  valueOffset: number,
+  conversionsByPngRel: Map<string, Conversion>,
+  editsByFile: Map<string, RewriteEdit[]>,
+  statsByPng: Map<string, RewriteStats>
+): void {
+  const urlRegex = /url\(\s*(?:(["'])(.*?)\1|([^'")]*?))\s*\)/gis;
+  let urlMatch: RegExpExecArray | null;
+
+  while ((urlMatch = urlRegex.exec(value)) !== null) {
+    const captured = urlMatch[2] ?? urlMatch[3] ?? "";
+    const token = getReferenceToken(captured);
+    if (!token) continue;
+
+    const capturedStart = urlMatch[0].indexOf(captured);
+    const start = valueOffset + urlMatch.index + capturedStart + token.startOffset;
+    addReferenceEdit(
+      filePath,
+      contentDir,
+      token.rawReference,
+      start,
+      start + token.rawReference.length,
+      conversionsByPngRel,
+      editsByFile,
+      statsByPng
+    );
+  }
+
+  scanImageSetReferences(
+    value,
+    filePath,
+    contentDir,
+    valueOffset,
+    conversionsByPngRel,
+    editsByFile,
+    statsByPng
+  );
+}
+
+function findFunctionEnd(value: string, bodyStart: number): number {
+  let depth = 1;
+  let index = bodyStart;
+
+  while (index < value.length) {
+    const char = value[index];
+
+    if (char === '"' || char === "'") {
+      index++;
+      while (index < value.length) {
+        if (value[index] === "\\") {
+          index += 2;
+          continue;
+        }
+        if (value[index] === char) break;
+        index++;
+      }
+    } else if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth--;
+      if (depth === 0) return index;
+    }
+
+    index++;
+  }
+
+  return -1;
+}
+
+function scanImageSetReferences(
+  value: string,
+  filePath: string,
+  contentDir: string,
+  valueOffset: number,
+  conversionsByPngRel: Map<string, Conversion>,
+  editsByFile: Map<string, RewriteEdit[]>,
+  statsByPng: Map<string, RewriteStats>
+): void {
+  const imageSetStartRegex = /\b(?:-webkit-)?image-set\s*\(/gis;
+
+  while (imageSetStartRegex.exec(value) !== null) {
+    const bodyStart = imageSetStartRegex.lastIndex;
+    const bodyEnd = findFunctionEnd(value, bodyStart);
+    if (bodyEnd === -1) break;
+
+    const imageSetBody = value.slice(bodyStart, bodyEnd);
+    const quotedReferenceRegex = /(["'])(.*?)\1/gis;
+    let quotedMatch: RegExpExecArray | null;
+
+    while ((quotedMatch = quotedReferenceRegex.exec(imageSetBody)) !== null) {
+      const beforeQuote = imageSetBody.slice(0, quotedMatch.index).trimEnd().toLowerCase();
+      if (beforeQuote.endsWith("url(")) continue;
+
+      const rawReference = quotedMatch[2];
+      if (!rawReference) continue;
+
+      const start =
+        valueOffset + bodyStart + quotedMatch.index + quotedMatch[0].indexOf(rawReference);
+      addReferenceEdit(
+        filePath,
+        contentDir,
+        rawReference,
+        start,
+        start + rawReference.length,
+        conversionsByPngRel,
+        editsByFile,
+        statsByPng
+      );
+    }
+
+    imageSetStartRegex.lastIndex = bodyEnd + 1;
+  }
+}
+
+function scanMarkupReferences(
+  content: string,
+  filePath: string,
+  contentDir: string,
+  conversionsByPngRel: Map<string, Conversion>,
+  editsByFile: Map<string, RewriteEdit[]>,
+  statsByPng: Map<string, RewriteStats>
+): void {
+  const attributeRegex = /\b(src|href|xlink:href|style|srcset)\s*=\s*(["'])(.*?)\2/gis;
+  let attrMatch: RegExpExecArray | null;
+
+  while ((attrMatch = attributeRegex.exec(content)) !== null) {
+    const attrName = attrMatch[1].toLowerCase();
+    const value = attrMatch[3];
+    const valueOffset = attrMatch.index + attrMatch[0].indexOf(value);
+
+    if (attrName === "style") {
+      scanCssReferences(
+        value,
+        filePath,
+        contentDir,
+        valueOffset,
+        conversionsByPngRel,
+        editsByFile,
+        statsByPng
+      );
+    } else if (attrName === "srcset") {
+      scanSrcsetReferences(
+        value,
+        filePath,
+        contentDir,
+        valueOffset,
+        conversionsByPngRel,
+        editsByFile,
+        statsByPng
+      );
+    } else {
+      addReferenceEdit(
+        filePath,
+        contentDir,
+        value,
+        valueOffset,
+        valueOffset + value.length,
+        conversionsByPngRel,
+        editsByFile,
+        statsByPng
+      );
+    }
+  }
+}
+
+async function buildRewritePlan(
+  contentDir: string,
+  conversions: Conversion[]
+): Promise<{
+  editsByFile: Map<string, RewriteEdit[]>;
+  statsByPng: Map<string, RewriteStats>;
+}> {
+  const conversionsByPngRel = new Map(
+    conversions.map((conversion) => [conversion.pngRel, conversion])
+  );
+  const editsByFile = new Map<string, RewriteEdit[]>();
+  const statsByPng = new Map<string, RewriteStats>();
+  const contentFiles = await collectFiles(contentDir, (filePath) =>
+    CONTENT_FILE_EXTENSIONS.has(path.extname(filePath).toLowerCase())
+  );
+
+  await Promise.all(
+    contentFiles.map(async (filePath) => {
+      const content = await fs.readFile(filePath, "utf8");
+      if (!content.toLowerCase().includes(".png")) return;
+
+      if (path.extname(filePath).toLowerCase() === ".css") {
+        scanCssReferences(
+          content,
+          filePath,
+          contentDir,
+          0,
+          conversionsByPngRel,
+          editsByFile,
+          statsByPng
+        );
+      } else {
+        scanMarkupReferences(
+          content,
+          filePath,
+          contentDir,
+          conversionsByPngRel,
+          editsByFile,
+          statsByPng
+        );
+      }
+    })
+  );
+
+  return { editsByFile, statsByPng };
+}
+
+async function buildOpfUpdatePlan(
+  epubDir: string,
+  contentDir: string,
+  conversions: Conversion[]
+): Promise<OpfUpdatePlan | null> {
   try {
     const opfFile = await getOPFPath(epubDir);
     const opfContent = await fs.readFile(opfFile, "utf8");
     const $opf = cheerio.load(opfContent, { xmlMode: true });
-    let changed = false;
-    for (const c of conversions) {
-      const items = $opf(`item[href="images/${c.pngBasename}"][media-type="image/png"]`);
-      if (items.length > 0) {
-        items.attr("href", `images/${c.jpegBasename}`);
-        items.attr("media-type", "image/jpeg");
-        changed = true;
-      }
-    }
-    if (changed) {
-      await fs.writeFile(opfFile, $opf.xml());
-      console.log(`Updated OPF file with ${conversions.length} new JPEG reference(s)`);
-    }
+    const conversionByPngRel = new Map(
+      conversions.map((conversion) => [conversion.pngRel, conversion])
+    );
+    const updates = new Map<string, string>();
+    const opfDir = path.dirname(opfFile);
+
+    $opf("item[href]").each((_, item) => {
+      const href = $opf(item).attr("href");
+      if (!href) return;
+
+      const resolved = resolveReference(opfFile, contentDir, href);
+      if (!resolved) return;
+
+      const conversion = conversionByPngRel.get(resolved.relPath);
+      if (!conversion) return;
+
+      const nextHref = encodeURI(toPosixPath(path.relative(opfDir, conversion.jpegFile)));
+      updates.set(conversion.pngRel, nextHref);
+    });
+
+    return { opfFile, contentDir, updates };
   } catch (opfError) {
     console.warn(
-      `Failed to update OPF file: ${opfError instanceof Error ? opfError.message : String(opfError)}`
+      `Failed to inspect OPF file: ${opfError instanceof Error ? opfError.message : String(opfError)}`
     );
+    return null;
+  }
+}
+
+async function applyCommittedEdits(
+  editsByFile: Map<string, RewriteEdit[]>,
+  committedPngs: ReadonlySet<string>
+): Promise<void> {
+  await Promise.all(
+    Array.from(editsByFile.entries()).map(async ([filePath, edits]) => {
+      const committedEdits = edits
+        .filter((edit) => committedPngs.has(edit.pngRel))
+        .sort((a, b) => b.start - a.start);
+
+      if (committedEdits.length === 0) return;
+
+      let content = await fs.readFile(filePath, "utf8");
+      for (const edit of committedEdits) {
+        content = content.slice(0, edit.start) + edit.replacement + content.slice(edit.end);
+      }
+      await fs.writeFile(filePath, content);
+      console.log(`Updated references in ${path.basename(filePath)}`);
+    })
+  );
+}
+
+async function applyOpfUpdates(
+  opfPlan: OpfUpdatePlan,
+  committedPngs: ReadonlySet<string>
+): Promise<void> {
+  if (committedPngs.size === 0) return;
+
+  const opfContent = await fs.readFile(opfPlan.opfFile, "utf8");
+  const $opf = cheerio.load(opfContent, { xmlMode: true });
+  let changed = 0;
+
+  $opf("item[href]").each((_, item) => {
+    const href = $opf(item).attr("href");
+    if (!href) return;
+
+    const resolved = resolveReference(opfPlan.opfFile, opfPlan.contentDir, href);
+    if (!resolved) return;
+
+    const updateHref = opfPlan.updates.get(resolved.relPath);
+
+    if (updateHref && committedPngs.has(resolved.relPath)) {
+      $opf(item).attr("href", updateHref);
+      $opf(item).attr("media-type", "image/jpeg");
+      changed++;
+    }
+  });
+
+  if (changed > 0) {
+    await fs.writeFile(opfPlan.opfFile, $opf.xml());
+    console.log(`Updated OPF file with ${changed} new JPEG reference(s)`);
   }
 }
 
@@ -163,13 +657,7 @@ async function convertPngToJpeg(
       return new Set();
     }
 
-    const imagesDir = path.join(contentDir, "images");
-    if (!(await fs.pathExists(imagesDir))) {
-      console.log("No images directory found, skipping PNG to JPEG conversion");
-      return new Set();
-    }
-
-    const pngFiles = glob.sync(path.join(imagesDir, "*.png"));
+    const pngFiles = await collectFiles(contentDir, (filePath) => PNG_EXT_RE.test(filePath));
     if (pngFiles.length === 0) {
       console.log("No PNG files found");
       return new Set();
@@ -180,7 +668,7 @@ async function convertPngToJpeg(
     // Phase 1: convert in parallel — each task writes its own .jpg side-by-side.
     const limit = pLimit(concurrency);
     const results = await Promise.all(
-      pngFiles.map((png) => limit(() => maybeConvertOne(png, quality, maxDim)))
+      pngFiles.map((png) => limit(() => maybeConvertOne(png, contentDir, quality, maxDim)))
     );
     const conversions = results.filter((r): r is Conversion => r !== null);
 
@@ -189,16 +677,61 @@ async function convertPngToJpeg(
       return new Set();
     }
 
-    // Phase 2: rewrite XHTML + OPF references once, then drop the PNG originals.
-    await rewriteXhtmlReferences(contentDir, conversions);
-    await rewriteOpfManifest(epubDir, conversions);
-    await Promise.all(conversions.map((c) => fs.remove(c.pngFile)));
+    // Phase 2: build a transaction plan. Nothing is rewritten until a PNG is
+    // proven safe to commit: referenced in supported content, all found
+    // references are planned, and the OPF manifest can be updated.
+    const [{ editsByFile, statsByPng }, opfPlan] = await Promise.all([
+      buildRewritePlan(contentDir, conversions),
+      buildOpfUpdatePlan(epubDir, contentDir, conversions),
+    ]);
+    const committedPngs = new Set<string>();
 
-    const totalSaved = conversions.reduce((sum, c) => sum + (c.originalSize - c.newSize), 0);
-    console.log(
-      `Converted ${conversions.length} PNG files to JPEG, saving ${formatBytes(totalSaved)}`
+    for (const conversion of conversions) {
+      const stats = statsByPng.get(conversion.pngRel) ?? { found: 0, planned: 0 };
+      const hasOpfUpdate = opfPlan?.updates.has(conversion.pngRel) ?? false;
+
+      if (!hasOpfUpdate) {
+        console.warn(`Keeping PNG ${conversion.pngRel}: no matching OPF manifest item found`);
+      } else if (stats.found === 0) {
+        console.warn(`Keeping PNG ${conversion.pngRel}: no supported content references found`);
+      } else if (stats.found !== stats.planned) {
+        console.warn(
+          `Keeping PNG ${conversion.pngRel}: planned ${stats.planned} rewrite(s) for ${stats.found} reference(s)`
+        );
+      } else {
+        committedPngs.add(conversion.pngRel);
+      }
+    }
+
+    await applyCommittedEdits(editsByFile, committedPngs);
+    if (opfPlan) {
+      await applyOpfUpdates(opfPlan, committedPngs);
+    }
+
+    await Promise.all(
+      conversions.map((conversion) =>
+        committedPngs.has(conversion.pngRel)
+          ? fs.remove(conversion.pngFile)
+          : fs.remove(conversion.jpegFile)
+      )
     );
-    return new Set(conversions.map((c) => c.jpegFile));
+
+    const committedConversions = conversions.filter((conversion) =>
+      committedPngs.has(conversion.pngRel)
+    );
+    if (committedConversions.length === 0) {
+      console.log("No PNG files were committed to JPEG conversion");
+      return new Set();
+    }
+
+    const totalSaved = committedConversions.reduce(
+      (sum, c) => sum + (c.originalSize - c.newSize),
+      0
+    );
+    console.log(
+      `Converted ${committedConversions.length} PNG files to JPEG, saving ${formatBytes(totalSaved)}`
+    );
+    return new Set(committedConversions.map((c) => c.jpegFile));
   } catch (error) {
     throw new Error(
       `Failed to convert PNG to JPEG: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
Rewrite PNG references by resolved path across XHTML, CSS, and SVG.

Commit or roll back converted JPEG candidates per image, add regression tests, and fix CLI usage examples.